### PR TITLE
Fixed fingerprinting alt instead of src #3

### DIFF
--- a/src/FingerPrintHandler.cs
+++ b/src/FingerPrintHandler.cs
@@ -86,9 +86,10 @@ namespace StaticWebHelper
             context.Response.AddFileDependency(physical);
 
             DateTime lastWrite = File.GetLastWriteTimeUtc(physical);
-            int index = value.LastIndexOf('.');
+            int index = path.LastIndexOf('.');
 
-            return value.Insert(index, "." + lastWrite.Ticks);
+            string pathFingerprint = path.Insert(index, "." + lastWrite.Ticks);                        
+            return value.Replace(path, pathFingerprint);
         }
 
         private static string AddCdn(HttpContext context, string value, string path)


### PR DESCRIPTION
The fingerprint is correctly added to the SRC attribute when the ALT
attribute contains a dot.